### PR TITLE
Improve Link Previews with Open Graph and Twitter Metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,18 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Open Graph Meta -->
+<meta property="og:title" content="Envoi – Your Digital Identity Passport for Voi" />
+<meta property="og:description" content="Claim your unique name, own your identity, and explore the Voi ecosystem." />
+<meta property="og:image" content="https://envoi.sh/og-preview.png" />
+<meta property="og:url" content="https://envoi.sh/" />
+<meta property="og:type" content="website" />
+
+<!-- Twitter Card Meta -->
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="Envoi – Your Digital Identity Passport for Voi" />
+<meta name="twitter:description" content="Claim your name and identity on Voi Network." />
+<meta name="twitter:image" content="https://envoi.sh/og-preview.png" />
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>enVoi | Voi Naming Service</title>


### PR DESCRIPTION
This PR adds Open Graph and Twitter Card metadata to `index.html` to ensure https://envoi.sh displays rich link previews on Discord, Twitter, Telegram, and other platforms.

The image `og-preview.png` should be served from the root (e.g., https://envoi.sh/og-preview.png) to match the meta tags and display correctly when shared.

This improves visibility, engagement, and brand consistency when sharing the Envoi landing page.

Preview image:
![og-preview](https://github.com/user-attachments/assets/aa796444-9af7-4016-866f-0e47e01fe406)
